### PR TITLE
Support for Multisite and a bunch of other changes

### DIFF
--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -24,7 +24,7 @@ class MarkupSitemapXML extends WireData implements Module {
 	 */
 	public function init() {
 		// Intercept a request for an URL ending in sitemap.xml and output
-		if (strlen($_SERVER['REQUEST_URI']) - strlen('/sitemap.xml') === strrpos($_SERVER['REQUEST_URI'], '/sitemap.xml')) {
+		if (isset($_SERVER['REQUEST_URI']) && strlen($_SERVER['REQUEST_URI']) - strlen('/sitemap.xml') === strrpos($_SERVER['REQUEST_URI'], '/sitemap.xml')) {
 			$this->addHookBefore("ProcessPageView::pageNotFound",$this,"renderSitemap");
 		}
 	}

--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -25,7 +25,7 @@ class MarkupSitemapXML extends WireData implements Module {
 	public function init() {
 		// Intercept a request for an URL ending in sitemap.xml and output
 		if (strpos($_SERVER['REQUEST_URI'], '/sitemap.xml', strlen($_SERVER['REQUEST_URI']) - strlen('/sitemap.xml')) !== FALSE) {
-			$this->addHookBefore("Page::render",$this,"renderSitemap");
+			$this->addHookBefore("ProcessPageView::pageNotFound",$this,"renderSitemap");
 		}
 	}
 

--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -35,6 +35,13 @@ class MarkupSitemapXML extends WireData implements Module {
 			$this->pageselector = '';
 			$langname = '';
 
+			// set startpage according to request (sitemap.xml spec says that sitemap
+			// should only contain pages below it's root page in page tree)
+			$startpage = $this->sanitizer->selectorValue(dirname($_SERVER['REQUEST_URI']));
+
+			// make sure that page used as root for sitemap actually exists
+			if ($this->pages->get($startpage) instanceof NullPage) return;
+
 			// support for LanguageLocalizedURL language module
 			if(wire("modules")->isInstalled("LanguageLocalizedURL")) {
 				$llu = wire("modules")->get("LanguageLocalizedURL");
@@ -49,11 +56,12 @@ class MarkupSitemapXML extends WireData implements Module {
 				$this->user->language = $this->languages->get($lang);
 			}
 			// Check for the cached sitemap, else generate and cache a fresh sitemap
+			$startpagestr = $this->sanitizer->pageName($startpage);
 			$cache =  wire('modules')->get("MarkupCache");
-			if(!$output = $cache->get("MarkupSitemapXML$langname", 3600)) {
+			if(!$output = $cache->get("MarkupSitemapXML$startpagestr$langname", 3600)) {
 				$output = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
 				$output .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-				$output .= $this->sitemapListPage(wire('pages')->get("/"));
+				$output .= $this->sitemapListPage(wire('pages')->get($startpage));
 				$output .= "\n</urlset>";
 				$cache->save($output);
 			}

--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -24,7 +24,7 @@ class MarkupSitemapXML extends WireData implements Module {
 	 */
 	public function init() {
 		// Intercept a request for an URL ending in sitemap.xml and output
-		if (strpos($_SERVER['REQUEST_URI'], '/sitemap.xml', strlen($_SERVER['REQUEST_URI']) - strlen('/sitemap.xml')) !== FALSE) {
+		if (strlen($_SERVER['REQUEST_URI']) - strlen('/sitemap.xml') === strrpos($_SERVER['REQUEST_URI'], '/sitemap.xml')) {
 			$this->addHookBefore("ProcessPageView::pageNotFound",$this,"renderSitemap");
 		}
 	}
@@ -43,7 +43,9 @@ class MarkupSitemapXML extends WireData implements Module {
 			// Multisite requires minor URL-related tweak
 			if (wire("modules")->isInstalled("Multisite")) {
 				$multisite = wire("modules")->get("Multisite");
-				$startpage = "/".$multisite->subdomain.$startpage;
+				if ($multisite->subdomain) {
+					$startpage = "/".$multisite->subdomain.$startpage;
+				}
 			}
 			
 			// make sure that page used as root for sitemap actually exists

--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -33,12 +33,19 @@ class MarkupSitemapXML extends WireData implements Module {
 			//$event->replace = true;
 			$lang = '';
 			$this->pageselector = '';
-			$langname = '';
+			$langname = ''; // for LanguageLocalizedUrl
+			$subdomain = ''; // for Multisite
 
 			// set startpage according to request (sitemap.xml spec says that sitemap
 			// should only contain pages below it's root page in page tree)
 			$startpage = $this->sanitizer->selectorValue(dirname($_SERVER['REQUEST_URI']));
 
+			// Multisite requires minor URL-related tweak
+			if (wire("modules")->isInstalled("Multisite")) {
+				$multisite = wire("modules")->get("Multisite");
+				$startpage = "/".$multisite->subdomain.$startpage;
+			}
+			
 			// make sure that page used as root for sitemap actually exists
 			if ($this->pages->get($startpage) instanceof NullPage) return;
 

--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -23,8 +23,8 @@ class MarkupSitemapXML extends WireData implements Module {
 	 *
 	 */
 	public function init() {
-		// Intercept a request for a root URL ending in sitemap.xml and output
-		if (strpos($_SERVER['REQUEST_URI'],  '/sitemap.xml') !== FALSE) {
+		// Intercept a request for an URL ending in sitemap.xml and output
+		if (strpos($_SERVER['REQUEST_URI'], '/sitemap.xml', strlen($_SERVER['REQUEST_URI']) - strlen('/sitemap.xml')) !== FALSE) {
 			$this->addHookBefore("Page::render",$this,"renderSitemap");
 		}
 	}


### PR DESCRIPTION
Had to make MarkupSitemapXML work with Multisite module for a project I'm currently working on and thought it might make sense to share some changes I've made to this module. Support for Multisite has been asked at least once or twice on the forums, after all :)

Other changes I've included in this pull request are related to how, when and based on what data sitemap is generated:
- Instead of Page::render, I've changed the hook to ProcessPageView::pageNotFound

This way user can add sitemap.xml -page (rare, but possible need) and this module won't automagically override it
- I've added extra check to make sure that request URI actually ends with "/sitemap.xml" and doesn't just contain it
- Related to Multisite support I've made sure that a sitemap accessed via any existing page of a site (such as /foo/bar/sitemap.xml, if /foo/bar/ is an existing page) works properly, ie. contains only pages below it's directory and not all the pages of that particular website (which is a limitation enforced by protocol section of sitemaps.org.)

After this addition a site with MarkupSitemapXML enabled theoretically contains proper sitemap file in each individual directory, though naturally most people won't link them anywhere or use them in any other way -- it just means that you can use directory-based sitemaps if there's a need for that :)
