### PR TITLE
text/xml -> application/xml

### DIFF
--- a/MarkupSitemapXML.module
+++ b/MarkupSitemapXML.module
@@ -75,7 +75,7 @@ class MarkupSitemapXML extends WireData implements Module {
 				$output .= "\n</urlset>";
 				$cache->save($output);
 			}
-			header("Content-Type: text/xml", true, 200);
+			header("Content-Type: application/xml", true, 200);
 			echo $output;
 			exit();
 	}


### PR DESCRIPTION
application/xml is the recommended MIME type for XML documents, regardless of their content. It is the standard choice for all XML files, including sitemap.xml.